### PR TITLE
Add support to build upstream package

### DIFF
--- a/.container
+++ b/.container
@@ -1,1 +1,0 @@
-ghcr.io/gardenlinux/repo-debian-snapshot@sha256:6ef03c0904ddff4485d33a430caf4f3919d14ef26e56d248a923961855c36570

--- a/prepare_source
+++ b/prepare_source
@@ -1,2 +1,37 @@
-apt_src google-guest-agent
+version_orig=20250122.00
 version_suffix=gl0
+
+# Clone upstream repository
+workdir="$(mktemp -d)"
+
+git clone --depth 1 --recurse-submodules --branch "${version_orig}" https://github.com/GoogleCloudPlatform/guest-agent.git "$workdir"
+
+pushd "$workdir"
+
+# Fix upstream Debian package definition
+mv ./packaging/debian ./
+
+latest_commit_message="$(git log -1 --pretty="format:%s" ./google_guest_agent)"
+latest_commit_datetime="$(git log -1 --pretty="format:%aD" ./google_guest_agent)"
+
+tee ./debian/changelog << EOF
+google-guest-agent (1:${version_orig}) stable; urgency=medium
+
+  * $latest_commit_message
+  * Detailed changelog an be found at https://github.com/GoogleCloudPlatform/guest-agent/commits/${version_orig}
+
+ -- $maintainer <$email>  $latest_commit_datetime
+EOF
+
+echo "3.0 (native)" > ./debian/source/format
+
+# Cleanup
+rm -rf ./.git
+rm -rf ./packaging
+
+popd
+
+# Import modified upstream source distribution
+import_src "$workdir"
+
+rm -rf "$workdir"


### PR DESCRIPTION
**What this PR does / why we need it**:
Debian upstream [discussed](https://www.mail-archive.com/debian-cloud@lists.debian.org/msg06833.html) to cease support for building `google-guest-agent` because of it's unmaintained state and as [Google Cloud Platform](https://github.com/GoogleCloudPlatform/guest-agent)  use their own packaging for distribution. Based on apparent removal of packages in Debian testing this PR switches to upstream as well.

Closes #1

**Which issue(s) this PR fixes**:
Fixes [#2621](https://github.com/gardenlinux/gardenlinux/issues/2621)