### PR TITLE
Fix issue with `google-guest-agent-manager.service`

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,10 +1,10 @@
 version_orig=20250122.00
-version_suffix=gl0
+version_suffix=gl1
 
 # Clone upstream repository
 workdir="$(mktemp -d)"
 
-git clone --depth 1 --recurse-submodules --branch "${version_orig}" https://github.com/GoogleCloudPlatform/guest-agent.git "$workdir"
+git clone --depth 1 --recurse-submodules --branch "${version_orig}" https://github.com/b1-systems/google-guest-agent.git "$workdir"
 
 pushd "$workdir"
 
@@ -18,7 +18,7 @@ tee ./debian/changelog << EOF
 google-guest-agent (1:${version_orig}) stable; urgency=medium
 
   * $latest_commit_message
-  * Detailed changelog an be found at https://github.com/GoogleCloudPlatform/guest-agent/commits/${version_orig}
+  * Detailed changelog an be found at https://github.com/b1-systems/google-guest-agent/commits/${version_orig}
 
  -- $maintainer <$email>  $latest_commit_datetime
 EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix issue with `google-guest-agent-manager.service` being installed without its binary by using a patched version if `debian/rules` suggested upstream.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/2625