### PR TITLE
Bump google-guest-agent version to 20250703.00+gl1+bp1877

### DIFF
--- a/.container
+++ b/.container
@@ -1,0 +1,1 @@
+ghcr.io/gardenlinux/repo-debian-snapshot@sha256:0348e829222f0e62c61cb68e630f1766b62e4311303bc35b02cbd5c62a98abef

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,4 +8,5 @@ jobs:
     uses: gardenlinux/package-build/.github/workflows/build.yml@main
     with:
       release: ${{ github.ref == 'refs/heads/main' }}
-      runs-on-arm64: ubuntu-24.04-arm
+      build_dep: |
+        gardenlinux/package-golang 1.24.4-1gl0+bp1877

--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,5 @@
 version_orig=20250703.00
-version_suffix=gl0
+version_suffix=gl1+bp1877
 
 # Clone upstream repository
 workdir="$(mktemp -d)"


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes to package definition to recompile google-guest-agent with GardenLinux golang release from 1877.

**Which issue(s) this PR fixes**:
Related https://github.com/gardenlinux/gardenlinux/issues/3197