### PR TITLE
Drop gl suffix from main

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,4 @@
 version_orig=20250703.00
-version_suffix=gl0
 
 # Clone upstream repository
 workdir="$(mktemp -d)"


### PR DESCRIPTION
**What this PR does / why we need it**:
According to our guidelines the gl suffix should only be added on requiring branches not on main.
The build workflows will add the "gl0"-suffix automatically, if it is not set.