### PR TITLE
chore: Use go version 1.25-7 for the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,3 +9,6 @@ jobs:
     with:
       release: ${{ github.ref == 'refs/heads/main' }}
       runs-on-arm64: ubuntu-24.04-arm
+      build_dep: |
+        gardenlinux/package-golang 1.25.7-2gl0
+        gardenlinux/package-golang-defaults 1.25gl0


### PR DESCRIPTION
**What this PR does / why we need it**:
We updated the default go version for the new release 2150.0.0 from using go version 1.24 to 1.25.
Hence, we need to rebuild all packages for the new release with this new go version.

This PR adds the required go version as build dependencies to the corresponding GitHub workflow.

**Which issue(s) this PR fixes**:
Part of: https://github.com/gardenlinux/gardenlinux/issues/3777