### PR TITLE
Build with go version 1.26.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
       release: ${{ github.ref == 'refs/heads/main' }}
       runs-on-arm64: ubuntu-24.04-arm
       build_dep: |
-        gardenlinux/package-golang 1.26.1-1gl0
+        gardenlinux/package-golang 1.26.2-1gl0


### PR DESCRIPTION
**What this PR does / why we need it**:
Update build dependencies to use go version `1.26.2`.

**Which issue(s) this PR fixes**:
Part of: [#4725](https://github.com/gardenlinux/gardenlinux/issues/4725)