### PR TITLE
Bump version to 20260520.01

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,4 +1,4 @@
-version_orig=20250703.00
+version_orig=20260520.01
 
 # Clone upstream repository
 workdir="$(mktemp -d)"


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the latest version available.

Part of: [#4879](https://github.com/gardenlinux/gardenlinux/issues/4879)